### PR TITLE
Fix code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Fixes [https://github.com/kehoedl/DevSecOps-Training/security/code-scanning/6](https://github.com/kehoedl/DevSecOps-Training/security/code-scanning/6)

To fix the problem, we need to enable CSRF protection in the `configure` method of the `WebSecurityConfig` class. This can be done by removing the call to `csrf().disable()` and allowing the default CSRF protection to be applied. This change ensures that the application is protected against CSRF attacks.

- Remove the line that disables CSRF protection (`csrf().disable()`) in the `configure` method.
- Ensure that the rest of the security configuration remains unchanged to maintain existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
